### PR TITLE
Fix: Standardize backend API access URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ python manage.py migrate
 # Start the Django API server
 python manage.py runserver
 ```
-API accessible at: ➡ http://localhost:8000
+API accessible at: ➡[http://127.0.0.1:8000/]
  (Django default port)
 
 #### 3-2. Frontend Server Setup (Vite + React/TypeScript)


### PR DESCRIPTION
## 🛠️ Correction

This small patch standardizes the backend API access address in the README.md documentation.

The URL was changed from the generic `http://localhost:8000` to the explicit **`http://127.0.0.1:8000`**.

This change ensures technical clarity, as `127.0.0.1` is the specific loopback address, which removes any ambiguity that can sometimes arise with hostname resolution when using `localhost` across different operating systems.

**Please review and merge.**

Closes #22