### PR TITLE
Docs: Add Read the Docs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+formats:
+  - htmlzip
+  - pdf
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
## Overview
This pull request adds the necessary configuration files required to build and host the project's documentation on ReadTheDocs.  
By introducing a `.readthedocs.yaml` file and a `docs/requirements.txt`, the documentation environment is now properly defined and ready for automated builds.

## Changes Included
- Added `.readthedocs.yaml` to the project root to configure the ReadTheDocs build environment.
- Added `docs/requirements.txt` to specify Sphinx and the ReadTheDocs theme as documentation dependencies.
- Configured:
  - Sphinx build path (`docs/conf.py`)
  - Python version (3.10)
  - Build tools and OS environment (Ubuntu 22.04)
  - Additional output formats (HTML, PDF)

## Purpose
This update allows:
- Automatic documentation builds via ReadTheDocs
- Consistent and reproducible documentation environments
- Alignment with modern ReadTheDocs configuration standards

## Impact
These additions do not affect project code or functionality.  
They only enhance documentation infrastructure and enable future documentation expansion.

## Issue Connection
Closes #32 