### PR TITLE
Docs: Add Sphinx requirements for ReadTheDocs

### DIFF
--- a/docs/docs/requirements.txt
+++ b/docs/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-rtd-theme


### PR DESCRIPTION
### Description
This Pull Request adds the `docs/requirements.txt` file required for ReadTheDocs to install the necessary dependencies when building the project documentation.

### Changes
The following file has been added:

- `docs/requirements.txt`
  - Contains the required Python packages for documentation builds:
    - `sphinx`
    - `sphinx-rtd-theme`

### Purpose
ReadTheDocs requires a `requirements.txt` inside the documentation directory so it can install the correct dependencies during the build process.  
This addition ensures:

- Proper Sphinx initialization  
- Compatibility with the ReadTheDocs environment  
- Successful future documentation builds

### How to Test
1. Confirm that the file exists at: `docs/requirements.txt`  
2. Ensure the listed dependencies are valid package names  
3. After merging, check ReadTheDocs build logs to verify that dependency installation succeeds

## Issue Connection
Closes #34 
