### PR TITLE
Docs: Add ReadTheDocs documentation link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Unlike traditional real estate platforms, CasaNova integrates and analyzes compl
 This project is fully open-source and free for anyone to use and contribute to.
 
 ---
+## 📚 Documentation
+
+CasaNova project documentation is available at the link below:
+
+➡ **https://casanova.readthedocs.io/en/latest/**
+
+---
 
 ## ✨ Core Features (주요 기능)
 


### PR DESCRIPTION
## Add ReadTheDocs Documentation Link to README.md

---

### Summary
This pull request updates the `README.md` by adding a direct link to the ReadTheDocs-hosted project documentation.

---

### Changes Made
- Added a **Documentation** section below the Project Introduction.
- Inserted the ReadTheDocs hosting URL.
- Organized the README to improve navigation and accessibility.

---

### Reason for Change
- The assignment requires adding the hosting link to the README.
- Enhances user and contributor onboarding.
- Follows open-source best practices by placing documentation links in a visible and standard location.

---

### Documentation Link Added
➡ **https://casanova.readthedocs.io/en/latest/** 
(Replace with your actual ReadTheDocs link if different.)

---

### Additional Notes
A documentation badge can also be added later if desired:

## Issue Connection
Closes #36 


