### PR TITLE
Docs: Add GitHub Pages website link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<<<<<<< HEAD
-=======
 # 🏠 CasaNova: Financial-Based Personalized Housing Recommendation System
 
 **_New Home, New Start._**
@@ -24,6 +22,20 @@ This project is fully open-source and free for anyone to use and contribute to.
 CasaNova project documentation is available at the link below:
 
 ➡ **https://casanova.readthedocs.io/en/latest/**
+
+---
+
+## 🌐 Project Website (GitHub Pages)
+
+The official CasaNova project website is available at the link below:
+
+➡ **https://whtjddms0714-byte.github.io/CasaNova/**
+
+This website includes:
+- Project overview & mission  
+- Documentation links  
+- Feature showcase  
+- Community & contact sections  
 
 ---
 


### PR DESCRIPTION
## 📄 Summary

This PR adds the official GitHub Pages website link for the CasaNova project to the README.md file.  
This update fulfills the documentation requirements for Deliverable 03, ensuring that both the ReadTheDocs documentation and the project website are easily accessible from the main project page.

---

## 🔧 Changes Made

### ✔ Added the following section to README.md:
**🌐 Project Website (GitHub Pages)**  
- Added direct link: https://whtjddms0714-byte.github.io/CasaNova/
- Placed below the Documentation section for better visibility.

### ✔ Improved project accessibility:
- Users can now directly access the hosted website.
- Enhances the professional presentation of the repository.

---

## 📚 Related Requirement

This PR satisfies the Deliverable 03 requirement:

> “Submit both the ReadTheDocs documentation link and the GitHub Pages website link.”

---
closes #52 
